### PR TITLE
Add video categorization and tagging system

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This project is under active development and many planned features are still a w
   - ✅ Dark/light mode support
   - ✅ Search functionality for videos
   - ✅ Sort videos by name or date
+  - ✅ Video categorization and tagging system
   - ✅ Open videos in system default player (fallback option)
   - ✅ Responsive layout that works on various screen sizes
 
@@ -40,7 +41,6 @@ This project is under active development and many planned features are still a w
 - **Features**
   - 🚧 Enable video thumbnails generation (backend ffmpeg support added)
   - 🚧 Multiple video selection for batch operations
-  - 🚧 Video categorization or tagging system
   - 🚧 Video editing capabilities (trim, crop, etc.)
   - 🚧 Export/share functionality for social media platforms
   - 🚧 Recent files list

--- a/src/pages/VideoPlayer.tsx
+++ b/src/pages/VideoPlayer.tsx
@@ -7,12 +7,14 @@ import { ArrowLeftIcon } from '@heroicons/react/24/outline';
 const VideoPlayer = () => {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
-  const { getVideoById, setSelectedVideo } = useDirectories();
+  const { getVideoById, setSelectedVideo, updateVideoMetadata } = useDirectories();
   const [video, setVideo] = useState<any>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [playerError, setPlayerError] = useState<string | null>(null);
   const playerRef = useRef<ReactPlayer>(null);
+  const [category, setCategory] = useState('');
+  const [tagsInput, setTagsInput] = useState('');
 
   useEffect(() => {
     if (id) {
@@ -20,6 +22,8 @@ const VideoPlayer = () => {
       if (foundVideo) {
         setVideo(foundVideo);
         setSelectedVideo(foundVideo);
+        setCategory(foundVideo.category || '');
+        setTagsInput(foundVideo.tags ? foundVideo.tags.join(', ') : '');
         setIsLoading(false);
       } else {
         setError(`Video not found with ID: ${id}`);
@@ -177,7 +181,7 @@ const VideoPlayer = () => {
           
           {/* Add a direct link to open the video in the system's default player */}
           <div className="mt-6">
-            <button 
+            <button
               onClick={() => {
                 // Try to open the file with the system's default video player
                 // This is a fallback if in-app playback doesn't work
@@ -186,6 +190,36 @@ const VideoPlayer = () => {
               className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
             >
               Open in Default Player
+            </button>
+          </div>
+
+          <div className="mt-6 space-y-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">Category</label>
+              <input
+                type="text"
+                className="mt-1 p-2 w-full border rounded-md dark:bg-gray-700 dark:text-gray-300"
+                value={category}
+                onChange={e => setCategory(e.target.value)}
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">Tags (comma separated)</label>
+              <input
+                type="text"
+                className="mt-1 p-2 w-full border rounded-md dark:bg-gray-700 dark:text-gray-300"
+                value={tagsInput}
+                onChange={e => setTagsInput(e.target.value)}
+              />
+            </div>
+            <button
+              onClick={() => {
+                const tags = tagsInput.split(',').map(t => t.trim()).filter(Boolean);
+                updateVideoMetadata(video.id, { category, tags });
+              }}
+              className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+            >
+              Save Metadata
             </button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add category and tags fields to video interface with persistence in localStorage
- expose updateVideoMetadata via DirectoryContext
- allow editing and saving category/tags in VideoPlayer
- filter and display categories and tags in VideoLibrary
- update README to mark categorization feature as complete

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f8659dc0c832f8b761d96ced1ec7e